### PR TITLE
Add support for string conversion for primitive types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,17 +153,19 @@ types are shown in the examples, but not required.
 #### `attr`
 
 ```
-`jsonapi:"attr,<key name in attributes hash>,<optional: omitempty>"`
+`jsonapi:"attr,<key name in attributes hash>,<optional: omitempty iso8601 string>"`
 ```
 
-These fields' values will end up in the `attributes`hash for a record.
+These fields' values will end up in the `attributes` hash for a record.
 The first argument must be, `attr`, and the second should be the name
-for the key to display in the `attributes` hash for that record. The optional
-third argument is `omitempty` - if it is present the field will not be present
+for the key to display in the `attributes` hash for that record. Afterwards, all 
+other arguments are optional. `omitempty`, if it is present the field will not be present
 in the `"attributes"` if the field's value is equivalent to the field types
 empty value (ie if the `count` field is of type `int`, `omitempty` will omit the
-field when `count` has a value of `0`). Lastly, the spec indicates that
-`attributes` key names should be dasherized for multiple word field names.
+field when `count` has a value of `0`). `iso8601` is used to indicate that timestamps are
+in ISO8601 format rather than UNIX format. `string` is used to convert field values to/from 
+JSON string. Lastly, the spec indicates that `attributes` key names should be dasherized for 
+multiple word field names.
 
 #### `relation`
 

--- a/constants.go
+++ b/constants.go
@@ -9,6 +9,7 @@ const (
 	annotationRelation  = "relation"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
+	annotationString    = "string"
 	annotationSeperator = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"

--- a/models_test.go
+++ b/models_test.go
@@ -191,3 +191,14 @@ type CustomAttributeTypes struct {
 	Float  CustomFloatType  `jsonapi:"attr,float"`
 	String CustomStringType `jsonapi:"attr,string"`
 }
+
+type ConversionAttributeTypes struct {
+	ID string `jsonapi:"primary,conversiontypes"`
+
+	Int        int  `jsonapi:"attr,int,string"`
+	IntPtr     *int `jsonapi:"attr,intptr,string"`
+	IntPtrNull *int `jsonapi:"attr,intptrnull,string"`
+
+	Float64 float64 `jsonapi:"attr,float64,string"`
+	Bool    bool    `jsonapi:"attr,bool,string"`
+}

--- a/request_test.go
+++ b/request_test.go
@@ -1306,3 +1306,47 @@ func TestUnmarshalNestedStructSlice(t *testing.T) {
 			out.Teams[0].Members[0].Firstname)
 	}
 }
+
+func TestUnmarshalStringAsNumeric(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "conversiontypes",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"int":        "5",
+				"intptr":     "5",
+				"intptrnull": nil,
+
+				"float64": "1.5",
+				"bool":    "true",
+			},
+		},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse JSON API payload
+	conversionAttributeTypes := new(ConversionAttributeTypes)
+	if err := UnmarshalPayload(bytes.NewReader(payload), conversionAttributeTypes); err != nil {
+		t.Fatal(err)
+	}
+
+	if expected, actual := int(5), conversionAttributeTypes.Int; expected != actual {
+		t.Fatalf("Was expecting converted int to be `%d`, got `%d`", expected, actual)
+	}
+	if expected, actual := int(5), *conversionAttributeTypes.IntPtr; expected != actual {
+		t.Fatalf("Was expecting converted int pointer to be `%d`, got `%d`", expected, actual)
+	}
+	if conversionAttributeTypes.IntPtrNull != nil {
+		t.Fatalf("Was expecting converted int pointer to be <nil>, got `%d`", conversionAttributeTypes.IntPtrNull)
+	}
+
+	if expected, actual := float64(1.5), conversionAttributeTypes.Float64; expected != actual {
+		t.Fatalf("Was expecting converted float to be `%f`, got `%f`", expected, actual)
+	}
+	if !conversionAttributeTypes.Bool {
+		t.Fatalf("Was expecting converted bool to be <true>, got `%v`", conversionAttributeTypes.Bool)
+	}
+}


### PR DESCRIPTION
Enhance jsonapi.UnmarshalPayload() to be able to unmarshal a JSON string into a bool, int, or float.

To inform Unmarshaler of anticipated type for JSON value add the annotation `string` to Struct field tag:
```
type MyStruct struct {
  ID string `jsonapi:"primary,id"`
  Int int `jsonapi:"attr,int,string"
}
```